### PR TITLE
Extension should use one of the pre-existing categories

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -7,5 +7,5 @@ metadata:
     - sidecar
   guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-dapr/dev/index.html"
   categories:
-    - "sidecar"
+    - "miscellaneous"
   status: "preview"


### PR DESCRIPTION
Otherwise they won't be listed in code.quarkus.io