### PR TITLE
feat: Generate a build item for each discovered component

### DIFF
--- a/demo/app1/src/main/resources/components/statestore.yaml
+++ b/demo/app1/src/main/resources/components/statestore.yaml
@@ -1,0 +1,10 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379

--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DaprContainerStartable.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DaprContainerStartable.java
@@ -7,43 +7,29 @@ import static io.quarkiverse.dapr.deployment.devservices.StateStoreContainerStar
 import static io.quarkiverse.dapr.deployment.devservices.StateStoreContainerStartable.POSTGRESQL_PORT;
 import static io.quarkiverse.dapr.deployment.devservices.StateStoreContainerStartable.USERNAME;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
-import org.yaml.snakeyaml.Yaml;
 
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
-import io.dapr.testcontainers.MetadataEntry;
 import io.quarkiverse.dapr.deployment.DaprProcessor;
 import io.quarkiverse.dapr.deployment.QuarkusPorts;
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.runtime.LaunchMode;
-import io.quarkus.runtime.util.ClassPathUtils;
 
 public class DaprContainerStartable extends DaprContainer implements Startable {
 
-    private static final String COMPONENTS_DIR = "components";
-    private static final Logger LOGGER = LoggerFactory.getLogger(DaprContainerStartable.class);
-
     private final DaprDevServiceBuildTimeConfig config;
 
-    public DaprContainerStartable(DaprDevServiceBuildTimeConfig config, LaunchMode launchMode, Network network) {
+    public DaprContainerStartable(DaprDevServiceBuildTimeConfig config, LaunchMode launchMode, Network network,
+            List<Component> components) {
         super(DockerImageName.parse(config.daprdImage()).asCompatibleSubstituteFor(
                 DAPR_RUNTIME_IMAGE_TAG));
 
@@ -58,17 +44,8 @@ public class DaprContainerStartable extends DaprContainer implements Startable {
         Testcontainers.exposeHostPorts(QuarkusPorts.http(launchMode),
                 QuarkusPorts.grpc(launchMode));
 
-        generateDeclaredComponents();
-    }
-
-    private void generateDeclaredComponents() {
-        try {
-            List<Component> components = tryGenerateComponents();
-            for (Component component : components) {
-                super.withComponent(component);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException("Unable to generate declared components", e);
+        for (Component component : components) {
+            super.withComponent(component);
         }
     }
 
@@ -93,68 +70,6 @@ public class DaprContainerStartable extends DaprContainer implements Startable {
         }
 
         super.start();
-    }
-
-    private List<Component> tryGenerateComponents() throws IOException {
-        Yaml yaml = new Yaml();
-
-        List<Component> components = new ArrayList<>();
-
-        ClassPathUtils.consumeAsPaths(Thread.currentThread().getContextClassLoader(),
-                COMPONENTS_DIR,
-                path -> {
-                    if (!Files.exists(path)) {
-                        return;
-                    }
-                    try (final Stream<Path> pathStream = Files.walk(path)) {
-                        pathStream.filter(Files::isRegularFile)
-                                .forEach(file -> tryGenerateComponentFromFile(yaml, file)
-                                        .ifPresent(components::add));
-                    } catch (IOException e) {
-                        throw new UncheckedIOException("Unable to generate component from resource", e);
-                    }
-                });
-
-        return components;
-    }
-
-    private static Optional<Component> tryGenerateComponentFromFile(Yaml yaml, Path file) {
-
-        String component;
-        try {
-            component = Files.readString(file);
-        } catch (IOException e) {
-            LOGGER.warn("Unable to read component file from {} file", file);
-            return Optional.empty();
-        }
-
-        Map<String, Object> document = yaml.load(component);
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> spec = (Map<String, Object>) document.get("spec");
-        String version = (String) spec.get("version");
-
-        String type = (String) spec.get("type");
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> metadata = (Map<String, Object>) document
-                .get("metadata");
-        String name = (String) metadata.get("name");
-
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> specMetadata = (List<Map<String, Object>>) spec
-                .getOrDefault("metadata", Collections.emptyMap());
-        List<MetadataEntry> metadataEntries = new ArrayList<>();
-
-        for (Map<String, Object> specMetadataItem : specMetadata) {
-            String metadataItemName = (String) specMetadataItem.get("name");
-            String metadataItemValue = (String) specMetadataItem
-                    .get("value");
-            metadataEntries
-                    .add(new MetadataEntry(metadataItemName,
-                            metadataItemValue));
-        }
-        return Optional.of(new Component(name, type, version, metadataEntries));
     }
 
     public void configureWithPgsqlStateStore() {

--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DashboardContainerStartable.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DashboardContainerStartable.java
@@ -46,7 +46,7 @@ public class DashboardContainerStartable extends WorkflowDashboardContainer impl
         super.withStateStoreComponent(new Component(PGSQL_STATE_STORE, "state.postgresql", "v2", POSTGRE_SQL_DETAILS));
     }
 
-    public void configureWithPgsqlStateStore() {
-
+    public void setupStateStore(Component component) {
+        super.withStateStoreComponent(component);
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DevServicesDaprProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DevServicesDaprProcessor.java
@@ -6,27 +6,43 @@ import static io.quarkiverse.dapr.deployment.devservices.StateStoreContainerStar
 import static io.quarkiverse.dapr.deployment.devservices.StateStoreContainerStartable.POSTGRESQL_PORT;
 import static io.quarkiverse.dapr.devui.DaprDashboardRPCService.DAPR_DASHBOARD_WORKFLOW_URL;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
+import org.yaml.snakeyaml.Yaml;
 
 import io.dapr.config.Properties;
+import io.dapr.testcontainers.Component;
+import io.dapr.testcontainers.MetadataEntry;
+import io.quarkiverse.dapr.deployment.items.DaprComponentBuildItem;
 import io.quarkiverse.dapr.devui.DaprDashboardRPCService;
+import io.quarkiverse.dapr.devui.DaprDashboardRecorder;
 import io.quarkus.arc.processor.BuiltinScope;
-import io.quarkus.deployment.IsLocalDevelopment;
 import io.quarkus.deployment.IsProduction;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.Startable;
 import io.quarkus.devui.spi.JsonRPCProvidersBuildItem;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
+import io.quarkus.runtime.util.ClassPathUtils;
 
 public class DevServicesDaprProcessor {
 
@@ -36,6 +52,7 @@ public class DevServicesDaprProcessor {
     private static final String DASHBOARD_WORKFLOW = QUARKUS_DAPR_SERVICE_NAME_PREFIX + "dashboard-workflow";
     private static final String STATESTORE_PG = QUARKUS_DAPR_SERVICE_NAME_PREFIX + "statestore-pgsql";
     private static final String POSTGRESQL_PORT_PROPERTY = "quarkus.dapr.devservices.dashboard.pgsql.port";
+    private static final String COMPONENTS_DIR = "components";
 
     @BuildStep
     public CardPageBuildItem cardPage() {
@@ -48,39 +65,147 @@ public class DevServicesDaprProcessor {
         return cardPageBuildItem;
     }
 
-    @BuildStep(onlyIf = IsLocalDevelopment.class)
+    @BuildStep(onlyIfNot = IsProduction.class)
     public JsonRPCProvidersBuildItem dashboardWorkflow() {
         return new JsonRPCProvidersBuildItem(DaprDashboardRPCService.class, BuiltinScope.SINGLETON.getName());
+    }
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep(onlyIfNot = IsProduction.class)
+    void setupRPCComponents(DaprDashboardRecorder recorder, List<DaprComponentBuildItem> componentBuildItems) {
+        List<DaprDashboardRPCService.DTOComponent> dtos = componentBuildItems.stream()
+                .map(item -> new DaprDashboardRPCService.DTOComponent(
+                        item.getName(),
+                        item.getType(),
+                        item.getVersion(),
+                        item.getMetadata()))
+                .collect(Collectors.toList());
+        recorder.setComponents(dtos);
+    }
+
+    @BuildStep
+    void discoverComponents(BuildProducer<DaprComponentBuildItem> componentProducer) {
+        try {
+            List<Component> components = tryGenerateComponents();
+            for (Component component : components) {
+                LOGGER.info("Discovered Dapr component: {} ({})", component.getName(), component.getType());
+                Map<String, String> metadata = component.getMetadata().stream()
+                        .collect(Collectors.toMap(MetadataEntry::getName, MetadataEntry::getValue, (v1, v2) -> v1));
+                componentProducer.produce(new DaprComponentBuildItem(
+                        component.getName(),
+                        component.getType(),
+                        component.getVersion(),
+                        metadata));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to generate declared components", e);
+        }
+    }
+
+    private List<Component> tryGenerateComponents() throws IOException {
+        Yaml yaml = new Yaml();
+
+        List<Component> components = new ArrayList<>();
+
+        ClassPathUtils.consumeAsPaths(Thread.currentThread().getContextClassLoader(),
+                COMPONENTS_DIR,
+                path -> {
+                    if (!Files.exists(path)) {
+                        return;
+                    }
+                    try (final Stream<Path> pathStream = Files.walk(path)) {
+                        pathStream.filter(Files::isRegularFile)
+                                .forEach(file -> tryGenerateComponentFromFile(yaml, file)
+                                        .ifPresent(components::add));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException("Unable to generate component from resource", e);
+                    }
+                });
+
+        return components;
+    }
+
+    private static Optional<Component> tryGenerateComponentFromFile(Yaml yaml, Path file) {
+
+        String component;
+        try {
+            component = Files.readString(file);
+        } catch (IOException e) {
+            LOGGER.warn("Unable to read component file from {} file", file);
+            return Optional.empty();
+        }
+
+        Map<String, Object> document = yaml.load(component);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> spec = (Map<String, Object>) document.get("spec");
+        String version = (String) spec.get("version");
+
+        String type = (String) spec.get("type");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> metadata = (Map<String, Object>) document
+                .get("metadata");
+        String name = (String) metadata.get("name");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> specMetadata = (List<Map<String, Object>>) spec
+                .getOrDefault("metadata", Collections.emptyList());
+        List<MetadataEntry> metadataEntries = new ArrayList<>();
+
+        for (Map<String, Object> specMetadataItem : specMetadata) {
+            String metadataItemName = (String) specMetadataItem.get("name");
+            String metadataItemValue = (String) specMetadataItem
+                    .get("value");
+            metadataEntries
+                    .add(new MetadataEntry(metadataItemName,
+                            metadataItemValue));
+        }
+        return Optional.of(new Component(name, type, version, metadataEntries));
     }
 
     @BuildStep(onlyIfNot = { IsProduction.class })
     List<DevServicesResultBuildItem> devServices(
             DaprDevServiceBuildTimeConfig config,
-            LaunchModeBuildItem launchMode) {
+            LaunchModeBuildItem launchMode,
+            List<DaprComponentBuildItem> componentBuildItems) {
 
         if (!config.enabled().get()) {
             return null;
         }
 
+        List<Component> components = componentBuildItems.stream()
+                .map(DaprComponentBuildItem::toComponent)
+                .collect(Collectors.toList());
+
         Network.NetworkImpl network = Network.builder()
                 .build();
 
         List<DevServicesResultBuildItem> containers = new ArrayList<>();
-        DevServicesResultBuildItem dapr = configureDaprContainer(config, launchMode, network);
+        DevServicesResultBuildItem dapr = configureDaprContainer(config, launchMode, network, components);
         containers.add(dapr);
 
         if (config.dashboard().enabled().get()) {
-            DevServicesResultBuildItem pgsql = configurePgsqlContainer(network);
-            DevServicesResultBuildItem dashboard = configureDashboardWorkflowContainer(network);
-            containers.add(dashboard);
-            containers.add(pgsql);
+            Optional<Component> dbComponent = components.stream()
+                    .filter(c -> "state.postgresql".equals(c.getType()))
+                    .findFirst();
+
+            if (dbComponent.isPresent()) {
+                DevServicesResultBuildItem dashboard = configureDashboardWorkflowContainer(network, dbComponent);
+                containers.add(dashboard);
+            } else {
+                DevServicesResultBuildItem pgsql = configurePgsqlContainer(network);
+                DevServicesResultBuildItem dashboard = configureDashboardWorkflowContainer(network, Optional.empty());
+                containers.add(dashboard);
+                containers.add(pgsql);
+            }
         }
 
         return containers;
     }
 
     private static DevServicesResultBuildItem configureDaprContainer(DaprDevServiceBuildTimeConfig config,
-            LaunchModeBuildItem launchMode, Network network) {
+            LaunchModeBuildItem launchMode, Network network, List<Component> components) {
         DevServicesResultBuildItem.OwnedServiceBuilder<Startable> builder = DevServicesResultBuildItem.owned()
                 .serviceName(FEATURE)
                 .feature(FEATURE)
@@ -88,7 +213,7 @@ public class DevServicesDaprProcessor {
                     @Override
                     public Startable get() {
                         return new DaprContainerStartable(config,
-                                launchMode.getLaunchMode(), network);
+                                launchMode.getLaunchMode(), network, components);
                     }
                 });
 
@@ -107,20 +232,25 @@ public class DevServicesDaprProcessor {
                 .build();
     }
 
-    private static DevServicesResultBuildItem configureDashboardWorkflowContainer(Network network) {
+    private static DevServicesResultBuildItem configureDashboardWorkflowContainer(Network network,
+            Optional<Component> dbComponent) {
         DevServicesResultBuildItem dashboard = DevServicesResultBuildItem.owned()
                 .serviceName(DASHBOARD_WORKFLOW)
                 .feature(FEATURE)
                 .startable(new Supplier<Startable>() {
                     @Override
                     public Startable get() {
-                        return new DashboardContainerStartable(network);
+                        DashboardContainerStartable container = new DashboardContainerStartable(network);
+                        dbComponent.ifPresent(container::setupStateStore);
+                        return container;
                     }
                 })
                 .dependsOnConfig(POSTGRESQL_PORT_PROPERTY, (Startable startable, String value) -> {
-                    LOGGER.info("Running dependsOnConfig for DashboardContainerStartable container");
-                    DashboardContainerStartable d = (DashboardContainerStartable) startable;
-                    d.setupStateStore();
+                    if (dbComponent.isEmpty()) {
+                        LOGGER.info("Running dependsOnConfig for DashboardContainerStartable container");
+                        DashboardContainerStartable d = (DashboardContainerStartable) startable;
+                        d.setupStateStore();
+                    }
                 })
                 .configProvider(Map.of(DAPR_DASHBOARD_WORKFLOW_URL, startable -> {
                     DashboardContainerStartable container = (DashboardContainerStartable) startable;

--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/items/DaprComponentBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/items/DaprComponentBuildItem.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.dapr.deployment.items;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import io.dapr.testcontainers.Component;
+import io.dapr.testcontainers.MetadataEntry;
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class DaprComponentBuildItem extends MultiBuildItem {
+
+    private final String name;
+    private final String type;
+    private final String version;
+    private final Map<String, String> metadata;
+
+    public DaprComponentBuildItem(String name, String type, String version, Map<String, String> metadata) {
+        this.name = name;
+        this.type = type;
+        this.version = version;
+        this.metadata = metadata == null ? Collections.emptyMap() : metadata;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public Component toComponent() {
+        List<MetadataEntry> metadataEntries = metadata.entrySet().stream()
+                .map(entry -> new MetadataEntry(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+        return new Component(name, type, version, metadataEntries);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/dapr/test/DaprComponentDiscoveryTest.java
+++ b/deployment/src/test/java/io/quarkiverse/dapr/test/DaprComponentDiscoveryTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.dapr.test;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.dapr.devui.DaprDashboardRPCService;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DaprComponentDiscoveryTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(DaprDashboardRPCService.class)
+                    .addClass(DaprDashboardRPCService.DTOComponent.class)
+                    .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                    .addAsResource("components/statestore.yaml", "components/statestore.yaml"))
+            .overrideConfigKey("quarkus.dapr.devservices.enabled", "false");
+
+    @Inject
+    DaprDashboardRPCService rpcService;
+
+    @Test
+    public void testComponentDiscovery() {
+        List<DaprDashboardRPCService.DTOComponent> components = rpcService.getComponents();
+        Assertions.assertNotNull(components);
+        Assertions.assertFalse(components.isEmpty(), "Components list should not be empty");
+
+        boolean found = components.stream().anyMatch(c -> "statestore".equals(c.name) && "state.redis".equals(c.type));
+        Assertions.assertTrue(found, "Discovered components should include 'statestore' of type 'state.redis'");
+    }
+}

--- a/deployment/src/test/resources/components/statestore.yaml
+++ b/deployment/src/test/resources/components/statestore.yaml
@@ -1,0 +1,10 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379

--- a/runtime/src/main/java/io/quarkiverse/dapr/devui/DaprDashboardRPCService.java
+++ b/runtime/src/main/java/io/quarkiverse/dapr/devui/DaprDashboardRPCService.java
@@ -1,23 +1,56 @@
 package io.quarkiverse.dapr.devui;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 
 import io.quarkus.runtime.annotations.JsonRpcDescription;
 
+@Singleton
 public class DaprDashboardRPCService {
 
     public static final String DAPR_DASHBOARD_WORKFLOW_URL = "quarkus.dapr.devservices.dashboard.url";
     private String url;
+    private List<DTOComponent> components = Collections.emptyList();
 
     @PostConstruct
     void init() {
-        url = ConfigProvider.getConfig().getValue(DAPR_DASHBOARD_WORKFLOW_URL, String.class);
+        url = ConfigProvider.getConfig().getOptionalValue(DAPR_DASHBOARD_WORKFLOW_URL, String.class).orElse("");
     }
 
     @JsonRpcDescription("Get the Dapr Dashboard Workflow URL")
     public String getDashboardWorkflowUrl() {
         return url;
+    }
+
+    public void setComponents(List<DTOComponent> components) {
+        this.components = components;
+    }
+
+    @JsonRpcDescription("Get the discovered Dapr components")
+    public List<DTOComponent> getComponents() {
+        return components;
+    }
+
+    public static class DTOComponent {
+        public String name;
+        public String type;
+        public String version;
+        public Map<String, String> metadata;
+
+        public DTOComponent() {
+        }
+
+        public DTOComponent(String name, String type, String version, Map<String, String> metadata) {
+            this.name = name;
+            this.type = type;
+            this.version = version;
+            this.metadata = metadata;
+        }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/dapr/devui/DaprDashboardRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/dapr/devui/DaprDashboardRecorder.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.dapr.devui;
+
+import java.util.List;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class DaprDashboardRecorder {
+
+    public void setComponents(List<DaprDashboardRPCService.DTOComponent> components) {
+        DaprDashboardRPCService service = Arc.container().instance(DaprDashboardRPCService.class).get();
+        if (service != null) {
+            service.setComponents(components);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes: #375 

Each Dapr component declared under `src/main/resources/components` is now discovered at build time and produced as a `DaprComponentBuildItem`, so other build steps (and other extensions) can react to the components in use instead of the container reading the YAML files itself.

The discovered components are also exposed to the Dev UI / Dev MCP through the `getComponents` JSON-RPC method of `DaprDashboardRPCService`.