### PR TITLE
refactor: support for other datacontenttypes

### DIFF
--- a/integration-tests/src/main/java/io/quarkiverse/dapr/demo/DaprResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/dapr/demo/DaprResource.java
@@ -16,12 +16,14 @@
  */
 package io.quarkiverse.dapr.demo;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 
 import io.dapr.Rule;
 import io.dapr.Topic;
+import io.dapr.client.domain.CloudEvent;
 
 @Path("/dapr")
 public class DaprResource {
@@ -71,5 +73,12 @@ public class DaprResource {
     @Topic(name = "${topic.six}", pubsubName = "${pubsub.six}", rule = @Rule(match = "${match.rule}", priority = 0))
     public String postTopic6() {
         return "Hello dapr";
+    }
+
+    @POST
+    @Path("/cloudevent")
+    @Consumes(CloudEvent.CONTENT_TYPE)
+    public String postCloudEvent(CloudEvent<String> event) {
+        return event.getData();
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/dapr/demo/DaprResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/dapr/demo/DaprResourceTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.dapr.client.domain.CloudEvent;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
@@ -27,5 +28,33 @@ public class DaprResourceTest {
                 .then()
                 .statusCode(200)
                 .body(is(resp));
+    }
+
+    @Test
+    public void testCloudEventApplicationXml() {
+        String xml = "<note>hello</note>";
+        String body = "{\"id\":\"1\",\"source\":\"/tests\",\"specversion\":\"1.0\",\"type\":\"test\","
+                + "\"datacontenttype\":\"application/xml\",\"data\":\"" + xml + "\"}";
+        given()
+                .contentType(CloudEvent.CONTENT_TYPE)
+                .body(body)
+                .when().post("/dapr/cloudevent")
+                .then()
+                .statusCode(200)
+                .body(is(xml));
+    }
+
+    @Test
+    public void testCloudEventTextXmlWithCharset() {
+        String xml = "<note>hi</note>";
+        String body = "{\"id\":\"2\",\"source\":\"/tests\",\"specversion\":\"1.0\",\"type\":\"test\","
+                + "\"datacontenttype\":\"text/xml; charset=utf-8\",\"data\":\"" + xml + "\"}";
+        given()
+                .contentType(CloudEvent.CONTENT_TYPE)
+                .body(body)
+                .when().post("/dapr/cloudevent")
+                .then()
+                .statusCode(200)
+                .body(is(xml));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/dapr/resteasy/CloudEventReader.java
+++ b/runtime/src/main/java/io/quarkiverse/dapr/resteasy/CloudEventReader.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.enterprise.inject.spi.CDI;
-import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -66,27 +65,34 @@ public class CloudEventReader implements MessageBodyReader<CloudEvent> {
 
     private static CloudEvent getCloudEvent(JsonNode jsonNode, JavaType valueType)
             throws IOException {
-        String dataContentType = jsonNode.get("datacontenttype").asText();
-        switch (dataContentType) {
-            case MediaType.APPLICATION_JSON:
-                return OBJECT_MAPPER.treeToValue(jsonNode, valueType);
-            case MediaType.TEXT_PLAIN:
-                String data = jsonNode.get("data").asText();
-                return OBJECT_MAPPER.readValue(data, valueType);
-            case MediaType.APPLICATION_OCTET_STREAM:
-                byte[] binaryData = jsonNode.get("data_base64").binaryValue();
-                String pubsubname = jsonNode.get("pubsubname").asText();
-                String rawPayload = Optional.ofNullable(DAPR_CONFIG.pubSub().get(pubsubname))
-                        .map(a -> a.consumeMetadata())
-                        .map(a -> a.get("rawPayload"))
-                        .orElse("");
-                if (Objects.equals("true", rawPayload)) {
-                    JsonNode subJsonNode = OBJECT_MAPPER.readTree(binaryData);
-                    return getCloudEvent(subJsonNode, valueType);
-                }
-                return OBJECT_MAPPER.readValue(binaryData, valueType);
-            default:
-                throw new NotSupportedException("can't read unknown cloud event content type: " + dataContentType);
+        String dataContentType = Optional.ofNullable(jsonNode.get("datacontenttype"))
+                .map(JsonNode::asText)
+                .orElse(MediaType.APPLICATION_JSON);
+        if (isOctetStream(dataContentType)) {
+            byte[] binaryData = jsonNode.get("data_base64").binaryValue();
+            String pubsubname = jsonNode.get("pubsubname").asText();
+            String rawPayload = Optional.ofNullable(DAPR_CONFIG.pubSub().get(pubsubname))
+                    .map(a -> a.consumeMetadata())
+                    .map(a -> a.get("rawPayload"))
+                    .orElse("");
+            if (Objects.equals("true", rawPayload)) {
+                JsonNode subJsonNode = OBJECT_MAPPER.readTree(binaryData);
+                return getCloudEvent(subJsonNode, valueType);
+            }
+            return OBJECT_MAPPER.readValue(binaryData, valueType);
+        }
+        return OBJECT_MAPPER.treeToValue(jsonNode, valueType);
+    }
+
+    private static boolean isOctetStream(String dataContentType) {
+        if (dataContentType == null) {
+            return false;
+        }
+        try {
+            MediaType mediaType = MediaType.valueOf(dataContentType);
+            return mediaType.isCompatible(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+        } catch (IllegalArgumentException ex) {
+            return dataContentType.startsWith(MediaType.APPLICATION_OCTET_STREAM);
         }
     }
 


### PR DESCRIPTION
I remade edition #299

Closes: #299 

- The class now implements `ServerMessageBodyReader<CloudEvent>` instead of the generic JAX-RS `MessageBodyReader`.
- Overloads for `isReadable(Class, Type, ResteasyReactiveResourceInfo, MediaType)` and `readFrom(Class, Type, MediaType, ServerRequestContext)` have been added. With these, RESTEasy Reactive no longer needs to call `Class.getMethod(...)` on the resource method for every request—an operation that caused failures in native binaries.
- The old JAX-RS versions have been retained, and both delegate to a single private `read` method, so behavior on the JVM remains unchanged.
- A brief Javadoc comment explains the reason for this change to prevent it from being reverted in the future.