### PR TITLE
fix: inner list when deserializer

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/DaprProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/DaprProcessor.java
@@ -41,6 +41,7 @@ import io.quarkiverse.dapr.endpoint.dapr.DaprConfigHandler;
 import io.quarkiverse.dapr.endpoint.dapr.DaprSubscribeHandler;
 import io.quarkiverse.dapr.endpoint.health.DaprHealthzHandler;
 import io.quarkiverse.dapr.jackson.DaprJacksonModuleCustomizer;
+import io.quarkiverse.dapr.resteasy.CloudEventDataReader;
 import io.quarkiverse.dapr.resteasy.CloudEventReader;
 import io.quarkiverse.dapr.runtime.DaprProducer;
 import io.quarkiverse.dapr.runtime.DaprRuntimeRecorder;
@@ -117,6 +118,8 @@ public class DaprProcessor {
     void vertxProviders(BuildProducer<MessageBodyReaderBuildItem> providers) {
         providers.produce(new MessageBodyReaderBuildItem(CloudEventReader.class.getName(), CloudEvent.class.getName(),
                 Collections.singletonList(MediaType.APPLICATION_JSON)));
+        providers.produce(new MessageBodyReaderBuildItem(CloudEventDataReader.class.getName(), Object.class.getName(),
+                Collections.singletonList(CloudEvent.CONTENT_TYPE)));
     }
 
     @BuildStep

--- a/integration-tests/src/main/java/io/quarkiverse/dapr/demo/OrderPrivateCtorWebhookResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/dapr/demo/OrderPrivateCtorWebhookResource.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.dapr.demo;
+
+import java.util.List;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import io.dapr.Topic;
+
+@Path("/webhook/orders-private")
+public class OrderPrivateCtorWebhookResource {
+
+    public static class Order {
+        public final String id;
+        public final List<OrderItem> items;
+
+        private Order(String id, List<OrderItem> items) {
+            this.id = id;
+            this.items = items;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public List<OrderItem> items() {
+            return items;
+        }
+    }
+
+    public static class OrderItem {
+        public final Long id;
+        public final String name;
+        public final double price;
+
+        private OrderItem(Long id, String name, double price) {
+            this.id = id;
+            this.name = name;
+            this.price = price;
+        }
+
+        public Long id() {
+            return id;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public double price() {
+            return price;
+        }
+    }
+
+    @POST
+    @Topic(pubsubName = "rabbitmq", name = "order.created")
+    public Response consume(Order order) {
+        return Response.ok(order.items().size()).build();
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/dapr/demo/OrderWebhookResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/dapr/demo/OrderWebhookResource.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.dapr.demo;
+
+import java.util.List;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import io.dapr.Topic;
+
+@Path("/webhook/orders")
+public class OrderWebhookResource {
+
+    public static class Order {
+        public final String id;
+        public final List<OrderItem> items;
+
+        Order(String id, List<OrderItem> items) {
+            this.id = id;
+            this.items = items;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public List<OrderItem> items() {
+            return items;
+        }
+    }
+
+    public static class OrderItem {
+        public final Long id;
+        public final String name;
+        public final double price;
+
+        OrderItem(Long id, String name, double price) {
+            this.id = id;
+            this.name = name;
+            this.price = price;
+        }
+
+        public Long id() {
+            return id;
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public double price() {
+            return price;
+        }
+    }
+
+    @POST
+    @Topic(pubsubName = "rabbitmq", name = "order.created")
+    public Response consume(Order order) {
+        return Response.ok(order.items().size()).build();
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/dapr/demo/DaprResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/dapr/demo/DaprResourceTest.java
@@ -1,10 +1,14 @@
 package io.quarkiverse.dapr.demo;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.dapr.client.domain.CloudEvent;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
@@ -21,11 +25,78 @@ public class DaprResourceTest {
 
     @Test
     public void testTopicEndpoint() {
-        String resp = "[{\"pubsubName\":\"pubsub.six\",\"topic\":\"topic-6\",\"routes\":{\"rules\":[{\"match\":\"event.type='found'\",\"path\":\"/dapr/topic6\"}]},\"metadata\":{}},{\"pubsubName\":\"pubsub\",\"topic\":\"topic-5\",\"route\":\"/dapr/topic5\",\"metadata\":{}},{\"pubsubName\":\"messagebus\",\"topic\":\"topic-4\",\"route\":\"/dapr/topic4\",\"metadata\":{\"test\":\"aaa\"}},{\"pubsubName\":\"messagebus\",\"topic\":\"test-topic2\",\"route\":\"/dapr\",\"metadata\":{\"test\":\"aaa\"}},{\"pubsubName\":\"messagebus\",\"topic\":\"test-topic3\",\"route\":\"/dapr/topic3\",\"metadata\":{\"test\":\"aaa\"}}]";
         given()
                 .when().get("/dapr/subscribe")
                 .then()
                 .statusCode(200)
-                .body(is(resp));
+                .body("", hasSize(6))
+                .body("find { it.pubsubName == 'pubsub.six' && it.topic == 'topic-6' }.routes.rules[0].match",
+                        is("event.type='found'"))
+                .body("find { it.pubsubName == 'pubsub.six' && it.topic == 'topic-6' }.routes.rules[0].path",
+                        is("/dapr/topic6"))
+                .body("find { it.pubsubName == 'pubsub.six' && it.topic == 'topic-6' }.metadata", anEmptyMap())
+                .body("find { it.pubsubName == 'pubsub' && it.topic == 'topic-5' }.route", is("/dapr/topic5"))
+                .body("find { it.pubsubName == 'pubsub' && it.topic == 'topic-5' }.metadata", anEmptyMap())
+                .body("find { it.pubsubName == 'rabbitmq' && it.topic == 'order.created' }.route",
+                        anyOf(is("/webhook/orders-private"), is("/webhook/orders")))
+                .body("find { it.pubsubName == 'rabbitmq' && it.topic == 'order.created' }.metadata", anEmptyMap())
+                .body("find { it.pubsubName == 'messagebus' && it.topic == 'topic-4' }.route", is("/dapr/topic4"))
+                .body("find { it.pubsubName == 'messagebus' && it.topic == 'topic-4' }.metadata.test", is("aaa"))
+                .body("find { it.pubsubName == 'messagebus' && it.topic == 'test-topic2' }.route", is("/dapr"))
+                .body("find { it.pubsubName == 'messagebus' && it.topic == 'test-topic2' }.metadata.test", is("aaa"))
+                .body("find { it.pubsubName == 'messagebus' && it.topic == 'test-topic3' }.route", is("/dapr/topic3"))
+                .body("find { it.pubsubName == 'messagebus' && it.topic == 'test-topic3' }.metadata.test", is("aaa"));
+    }
+
+    @Test
+    public void testCloudEventUnwrapsDataIntoPojo() {
+        String event = "{"
+                + "\"data\":{"
+                + "\"id\":\"fa985994-78ce-4013-9029-81dad4787a4a\","
+                + "\"items\":[{\"id\":1,\"name\":\"Quarkus Stickers\",\"price\":19.99}]"
+                + "},"
+                + "\"datacontenttype\":\"application/json\","
+                + "\"id\":\"10e48bf4-bc1b-4b0a-9d76-02dc9e095f55\","
+                + "\"pubsubname\":\"rabbitmq\","
+                + "\"source\":\"orders-api\","
+                + "\"specversion\":\"1.0\","
+                + "\"time\":\"2025-10-06T20:47:45Z\","
+                + "\"topic\":\"order.created\","
+                + "\"type\":\"com.dapr.event.sent\""
+                + "}";
+
+        given()
+                .contentType(CloudEvent.CONTENT_TYPE)
+                .body(event)
+                .when().post("/webhook/orders")
+                .then()
+                .statusCode(200)
+                .body(is("1"));
+    }
+
+    @Test
+    public void testCloudEventUnwrapsDataIntoPojoWithNonPublicCtors() {
+        String event = "{"
+                + "\"data\":{"
+                + "\"id\":\"fa985994-78ce-4013-9029-81dad4787a4a\","
+                + "\"items\":[{\"id\":1,\"name\":\"Quarkus Stickers\",\"price\":19.99}]"
+                + "},"
+                + "\"datacontenttype\":\"application/json\","
+                + "\"id\":\"10e48bf4-bc1b-4b0a-9d76-02dc9e095f55\","
+                + "\"pubsubname\":\"rabbitmq\","
+                + "\"source\":\"orders-api\","
+                + "\"specversion\":\"1.0\","
+                + "\"time\":\"2025-10-06T20:47:45Z\","
+                + "\"topic\":\"order.created\","
+                + "\"type\":\"com.dapr.event.sent\""
+                + "}";
+
+        given()
+                .contentType(CloudEvent.CONTENT_TYPE)
+                .body(event)
+                .when().post("/webhook/orders-private")
+                .then()
+                .statusCode(200)
+                .body(is("1"));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/dapr/jackson/DaprJacksonModuleCustomizer.java
+++ b/runtime/src/main/java/io/quarkiverse/dapr/jackson/DaprJacksonModuleCustomizer.java
@@ -7,7 +7,9 @@ import java.time.format.DateTimeFormatter;
 
 import jakarta.inject.Singleton;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -43,6 +45,9 @@ public class DaprJacksonModuleCustomizer implements ObjectMapperCustomizer {
 
         // null属性不序列化
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        // allow non-public record constructors (e.g., nested records)
+        objectMapper.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY);
 
         // 能解析注释符
         objectMapper.enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature());

--- a/runtime/src/main/java/io/quarkiverse/dapr/resteasy/CloudEventDataReader.java
+++ b/runtime/src/main/java/io/quarkiverse/dapr/resteasy/CloudEventDataReader.java
@@ -1,0 +1,115 @@
+package io.quarkiverse.dapr.resteasy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.dapr.client.domain.CloudEvent;
+import io.quarkiverse.dapr.config.DaprConfig;
+
+/**
+ * Reads a Dapr CloudEvent and deserializes its {@code data} into the requested JAX-RS parameter type.
+ *
+ * This allows resource methods to work when Dapr sends to work when Dapr sends
+ * {@code Content-Type: application/cloudevents+json}.
+ */
+@Provider
+@Consumes(CloudEvent.CONTENT_TYPE)
+public class CloudEventDataReader implements MessageBodyReader<Object> {
+
+    private static ObjectMapper OBJECT_MAPPER;
+    private static DaprConfig DAPR_CONFIG;
+    private static final Map<Type, JavaType> TYPE_CACHE = new ConcurrentHashMap<>();
+
+    public CloudEventDataReader() {
+        if (OBJECT_MAPPER == null) {
+            OBJECT_MAPPER = CDI.current().select(ObjectMapper.class).get();
+        }
+        if (DAPR_CONFIG == null) {
+            DAPR_CONFIG = CDI.current().select(DaprConfig.class).get();
+        }
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        // Let CloudEventReader handle CloudEvent<T> endpoints.
+        return type != CloudEvent.class;
+    }
+
+    @Override
+    public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        JavaType targetType = TYPE_CACHE.computeIfAbsent(genericType,
+                a -> OBJECT_MAPPER.getTypeFactory().constructType(genericType));
+
+        JsonNode cloudEventNode = OBJECT_MAPPER.readTree(entityStream);
+        JsonNode dataNode = cloudEventNode.get("data");
+        JsonNode base64Node = cloudEventNode.get("data_base64");
+
+        if (dataNode == null && base64Node == null) {
+            return OBJECT_MAPPER.treeToValue(cloudEventNode, targetType);
+        }
+
+        String dataContentType = Optional.ofNullable(cloudEventNode.get("datacontenttype"))
+                .map(JsonNode::asText)
+                .filter(s -> !s.isBlank())
+                .orElse(MediaType.APPLICATION_JSON);
+
+        switch (dataContentType) {
+            case MediaType.APPLICATION_JSON:
+                if (dataNode == null || dataNode.isNull()) {
+                    return null;
+                }
+                return OBJECT_MAPPER.treeToValue(dataNode, targetType);
+            case MediaType.TEXT_PLAIN:
+                if (dataNode == null || dataNode.isNull()) {
+                    return null;
+                }
+                String dataText = dataNode.asText();
+                if (Objects.equals(String.class, targetType.getRawClass())) {
+                    return dataText;
+                }
+                return OBJECT_MAPPER.readValue(dataText, targetType);
+            case MediaType.APPLICATION_OCTET_STREAM:
+                if (base64Node == null || base64Node.isNull()) {
+                    return null;
+                }
+                byte[] binaryData = base64Node.binaryValue();
+                if (Objects.equals(byte[].class, targetType.getRawClass())) {
+                    return binaryData;
+                }
+                String pubsubname = Optional.ofNullable(cloudEventNode.get("pubsubname"))
+                        .map(JsonNode::asText)
+                        .orElse("");
+                String rawPayload = Optional.ofNullable(DAPR_CONFIG.pubSub().get(pubsubname))
+                        .map(a -> a.consumeMetadata())
+                        .map(a -> a.get("rawPayload"))
+                        .orElse("");
+                if (Objects.equals("true", rawPayload)) {
+                    JsonNode payloadNode = OBJECT_MAPPER.readTree(binaryData);
+                    return OBJECT_MAPPER.treeToValue(payloadNode, targetType);
+                }
+                return OBJECT_MAPPER.readValue(binaryData, targetType);
+            default:
+                throw new NotSupportedException("can't read unknown cloud event content type: " + dataContentType);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #336

 The Problem: 
When a resource method receives the event payload directly (e.g. `consume(Order order)`),
the request body is the whole CloudEvent envelope, so Jackson tries to map the envelope
onto `Order`. Nested fields such as `items` end up `null`.

## Solution

- Add `CloudEventDataReader`, a `MessageBodyReader<Object>` registered for
  `application/cloudevents+json`. It reads the CloudEvent, extracts `data`
  (or `data_base64`) according to `datacontenttype` and deserializes it into the
  requested parameter type. `CloudEvent<T>` parameters are still handled by the
  existing `CloudEventReader`.
- Register the reader as a CDI bean so `ObjectMapper` and `DaprConfig` are injected
  through the constructor.
- Enable `PropertyAccessor.CREATOR` visibility `ANY` in `DaprJacksonModuleCustomizer`,
  so types with non-public constructors (e.g. nested records) can be deserialized.