### PR TITLE
Dapr DevServices failing some times

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/DaprProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/DaprProcessor.java
@@ -90,8 +90,12 @@ public class DaprProcessor {
             NonApplicationRootPathBuildItem nonApplicationRootPathBuildItem) {
         routeBuildItemBuildProducer.produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new DaprConfigHandler()));
 
+        routeBuildItemBuildProducer.produce(getDaprAppRouteBuildItem(new DaprConfigHandler()));
+
         routeBuildItemBuildProducer.produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new DaprSubscribeHandler()));
+        routeBuildItemBuildProducer.produce(getDaprAppRouteBuildItem(new DaprSubscribeHandler()));
         routeBuildItemBuildProducer.produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new DaprHealthzHandler()));
+        routeBuildItemBuildProducer.produce(getDaprAppRouteBuildItem(new DaprHealthzHandler()));
     }
 
     @BuildStep
@@ -100,11 +104,19 @@ public class DaprProcessor {
         routeBuildItemBuildProducer
                 .produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new ActorDeactivateHandler()));
         routeBuildItemBuildProducer
+                .produce(getDaprAppRouteBuildItem(new ActorDeactivateHandler()));
+        routeBuildItemBuildProducer
                 .produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new ActorInvokeMethodHandler()));
+        routeBuildItemBuildProducer
+                .produce(getDaprAppRouteBuildItem(new ActorInvokeMethodHandler()));
         routeBuildItemBuildProducer
                 .produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new ActorInvokeTimerHandler()));
         routeBuildItemBuildProducer
+                .produce(getDaprAppRouteBuildItem(new ActorInvokeTimerHandler()));
+        routeBuildItemBuildProducer
                 .produce(getDaprRouteBuildItem(nonApplicationRootPathBuildItem, new ActorInvokeReminderHandler()));
+        routeBuildItemBuildProducer
+                .produce(getDaprAppRouteBuildItem(new ActorInvokeReminderHandler()));
     }
 
     @BuildStep
@@ -245,6 +257,21 @@ public class DaprProcessor {
             AbstractDaprHandler handler) {
         return nonApplicationRootPathBuildItem.routeBuilder()
                 .nestedRoute(handler.baseRoute(), handler.subRoute())
+                .handler(handler)
+                .displayOnNotFoundPage()
+                .build();
+    }
+
+    private RouteBuildItem getDaprAppRouteBuildItem(AbstractDaprHandler handler) {
+        String route = handler.baseRoute();
+        String subRoute = handler.subRoute();
+        if (StringUtils.isNotBlank(subRoute)) {
+            route = route + "/" + subRoute;
+        }
+        route = route.replaceAll("//", "/");
+
+        return RouteBuildItem.builder()
+                .route(route)
                 .handler(handler)
                 .displayOnNotFoundPage()
                 .build();

--- a/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DaprContainerStartable.java
+++ b/deployment/src/main/java/io/quarkiverse/dapr/deployment/devservices/DaprContainerStartable.java
@@ -29,6 +29,7 @@ import org.yaml.snakeyaml.Yaml;
 import io.dapr.testcontainers.Component;
 import io.dapr.testcontainers.DaprContainer;
 import io.dapr.testcontainers.DaprLogLevel;
+import io.dapr.testcontainers.DaprProtocol;
 import io.dapr.testcontainers.MetadataEntry;
 import io.quarkiverse.dapr.deployment.DaprProcessor;
 import io.quarkiverse.dapr.deployment.QuarkusPorts;
@@ -51,6 +52,8 @@ public class DaprContainerStartable extends DaprContainer implements Startable {
 
         super.withAppName("local-dapr-app")
                 .withAppPort(QuarkusPorts.http(launchMode))
+                .withAppProtocol(DaprProtocol.HTTP)
+                .withAppHealthCheckPath("/healthz")
                 .withDaprLogLevel(DaprLogLevel.DEBUG)
                 .withNetwork(network)
                 .withAppChannelAddress("host.testcontainers.internal");

--- a/integration-tests/src/test/java/io/quarkiverse/dapr/demo/DaprSubscribeAndHealthTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/dapr/demo/DaprSubscribeAndHealthTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.dapr.demo;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class DaprSubscribeAndHealthTest {
+
+    private static final String SUBSCRIBE_RESPONSE = "[{\"pubsubName\":\"pubsub.six\",\"topic\":\"topic-6\",\"routes\":{\"rules\":[{\"match\":\"event.type='found'\",\"path\":\"/dapr/topic6\"}]},\"metadata\":{}},{\"pubsubName\":\"pubsub\",\"topic\":\"topic-5\",\"route\":\"/dapr/topic5\",\"metadata\":{}},{\"pubsubName\":\"messagebus\",\"topic\":\"topic-4\",\"route\":\"/dapr/topic4\",\"metadata\":{\"test\":\"aaa\"}},{\"pubsubName\":\"messagebus\",\"topic\":\"test-topic2\",\"route\":\"/dapr\",\"metadata\":{\"test\":\"aaa\"}},{\"pubsubName\":\"messagebus\",\"topic\":\"test-topic3\",\"route\":\"/dapr/topic3\",\"metadata\":{\"test\":\"aaa\"}}]";
+
+    @Test
+    public void testSubscribeEndpointOnApplicationRoot() {
+        given()
+                .when().get("/dapr/subscribe")
+                .then()
+                .statusCode(200)
+                .body(is(SUBSCRIBE_RESPONSE));
+    }
+
+    @Test
+    public void testSubscribeEndpointOnNonApplicationRoot() {
+        given()
+                .when().get("/q/dapr/subscribe")
+                .then()
+                .statusCode(200)
+                .body(is(SUBSCRIBE_RESPONSE));
+    }
+
+    @Test
+    public void testHealthzEndpointOnApplicationRoot() {
+        given()
+                .when().get("/healthz")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testHealthzEndpointOnNonApplicationRoot() {
+        given()
+                .when().get("/q/healthz")
+                .then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
Fixes: #297 

DevService ensuring that the GET endpoint /dapr/subscribe is available before the Dapr DevService, avoiding the race condition that caused /dapr/subscribe to fail sporadically.