### PR TITLE
Move native image build out of PR checks into a nightly workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,3 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B formatter:validate install --file pom.xml
-
-      - name: Build with Native
-        if: success()
-        run: mvn -Dnative -Dquarkus.native.container-build=true -B install --file pom.xml

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,26 @@
+name: Native Build
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Native Build on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: 'maven'
+
+      - name: Build with Native
+        run: mvn -Dnative -Dquarkus.native.container-build=true -B install --file pom.xml


### PR DESCRIPTION
## Summary
- Remove the native image build step from the PR/push build workflow to reduce check time
- Add a new nightly workflow that runs the native build on a schedule (also triggerable manually via workflow_dispatch)

## Test plan
- [x] Confirm `Build` workflow runs faster and no longer builds native image
- [x] Confirm `Native Build` workflow runs successfully on schedule / manual trigger